### PR TITLE
Removed redundant code

### DIFF
--- a/controls/aws-foundations-cis-1.14.rb
+++ b/controls/aws-foundations-cis-1.14.rb
@@ -55,7 +55,6 @@ control "aws-foundations-cis-1.14" do
 
   
   describe aws_iam_root_user do
-    it { should_not have_virtual_mfa_enabled }
     it { should have_hardware_mfa_enabled }
   end
 end


### PR DESCRIPTION
Both the statements in the describe block perform the same check so one of them has been removed.

Signed-off-by: karikarshivani <karikarshivani@gmail.com>